### PR TITLE
Small steps directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,4 +25,17 @@
       <version>0.6</version>
     </dependency>
   </dependencies>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/jnr/process/ProcessBuilder.java
+++ b/src/main/java/jnr/process/ProcessBuilder.java
@@ -12,6 +12,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import java.io.File;
+
 /**
  * Created by headius on 1/19/15.
  */
@@ -31,12 +33,23 @@ public class ProcessBuilder {
         return new ArrayList<String>(command);
     }
 
-    public void command(List<String> command) {
+    public ProcessBuilder command(List<String> command) {
         this.command = new ArrayList<String>(command);
+        return this;
     }
 
-    public void command(String... command) {
+    public ProcessBuilder command(String... command) {
         this.command = Arrays.asList(command);
+        return this;
+    }
+
+    public File directory() {
+        return new File(posix.getcwd());
+    }
+
+    public ProcessBuilder directory(String dir) {
+        posix.chdir(dir);
+        return this;
     }
 
     public Process start() {


### PR DESCRIPTION
A few small additions that made it more useful for me™

I needed to add that stanza in the pom.xml for `mvn install` to work. To be able to set the directory where the process executes I added `directory` methods as in java's own ProcessBuilder. Not 100% sure about them though.

does `posix.chdir` change the working directory of the parent process (i.e. the JVM?) Should `posix` be an instance variable instead of a static? Is a completely different approach needed?

In any case thanks a million for this! I am now able to launch a `lein repl` from Clojure and send/receive commands. Next step: combine it with Selenium for full blown integration tests for [Chestnut](https://github.com/plexus/chestnut).

``` clojure
(let [buf (java.nio.ByteBuffer/allocate 2048)]
  (defn read-next [chan]
    (.clear buf)
    (.read chan buf)
    (String. (into-array Character/TYPE (take (.position buf) (.array buf))))))

(let [buf (java.nio.ByteBuffer/allocate 2048)]
  (defn write-next [chan exp]
    (.clear buf)
    (.put buf (into-array Byte/TYPE (str exp)))
    (.flip buf)
    (.write chan buf)))

(def repl-process
  (-> (jnr.process.ProcessBuilder. (into-array ["lein" "repl"]))
      (.directory "/tmp/sesame-seed")
      (.start)))

(.configureBlocking (.getIn repl-process) false)
(.configureBlocking (.getErr repl-process) false)

(def selector (.openSelector (jnr.enxio.channels.NativeSelectorProvider/getInstance)))
(def selection-key (.register (.getIn repl-process) selector java.nio.channels.SelectionKey/OP_READ))
(def selection-key (.register (.getErr repl-process) selector java.nio.channels.SelectionKey/OP_READ))

(.selectNow selector)

(read-next (.channel (first (.selectedKeys selector))))
(write-next (.getOut repl-process) "(+ 1 1)\n")
```