### PR TITLE
Provide a kill method on Process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,17 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.0.9</version>
+      <version>3.0.10-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
       <version>0.6</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-constants</artifactId>
+      <version>0.8.7-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/jnr/process/Process.java
+++ b/src/main/java/jnr/process/Process.java
@@ -3,6 +3,7 @@ package jnr.process;
 import jnr.enxio.channels.NativeDeviceChannel;
 import jnr.enxio.channels.NativeSelectorProvider;
 import jnr.posix.POSIX;
+import jnr.constants.platform.Signal;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -69,6 +70,14 @@ public class Process {
         exitValue = status[0];
 
         return exitValue;
+    }
+
+    public int kill() {
+        return kill(Signal.SIGKILL);
+    }
+
+    public int kill(Signal sig) {
+        return posix.kill(pid, sig.intValue());
     }
 
     public long exitValue() {


### PR DESCRIPTION
This adds a dependency on jnr-constants for the signal values.

I wasn't sure about the dependency versions. Is it ok to depend on snapshots? https://github.com/jnr/jnr-posix/pull/41 will need to go in for this code to work, so jnr-posix 3.0.9 is not enough.

Replaces #2 