### PR TITLE
Add a getter for Process.getPid

### DIFF
--- a/src/main/java/jnr/process/Process.java
+++ b/src/main/java/jnr/process/Process.java
@@ -33,6 +33,10 @@ public class Process {
         this.err = new NativeDeviceChannel(NativeSelectorProvider.getInstance(), err, SelectionKey.OP_READ);
     }
 
+    public long getPid() {
+        return pid;
+    }
+
     public SelectableChannel getOut() {
         return out;
     }


### PR DESCRIPTION
Add `getPid`. I tried to avoid exposing that, but it's just really handy sometimes to be able to look at that.