### PR TITLE
Fixed a type error in Process.java and added ProcessBuilder.environment()

### DIFF
--- a/src/main/java/jnr/process/Process.java
+++ b/src/main/java/jnr/process/Process.java
@@ -81,7 +81,7 @@ public class Process {
     }
 
     public int kill(Signal sig) {
-        return posix.kill(pid, sig.intValue());
+        return posix.kill((int)pid, sig.intValue());
     }
 
     public int killProcessGroup() {
@@ -89,7 +89,7 @@ public class Process {
     }
 
     public int killProcessGroup(Signal sig) {
-        return posix.kill(-pid, sig.intValue());
+        return posix.kill(-(int)pid, sig.intValue());
     }
 
     public long exitValue() {

--- a/src/main/java/jnr/process/ProcessBuilder.java
+++ b/src/main/java/jnr/process/ProcessBuilder.java
@@ -1,30 +1,31 @@
 package jnr.process;
 
-import jnr.posix.POSIX;
-import jnr.posix.POSIXFactory;
-import jnr.posix.SpawnAttribute;
-import jnr.posix.SpawnFileAction;
-
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.SpawnFileAction;
 
 /**
  * Created by headius on 1/19/15.
  */
 public class ProcessBuilder {
     private List<String> command;
+    private Map<String, String> env;
+    
     private static final POSIX posix = POSIXFactory.getPOSIX();
 
     public ProcessBuilder(List<String> command) {
         this.command = new ArrayList<String>(command);
+        this.env = new HashMap<String, String>(System.getenv());
     }
 
     public ProcessBuilder(String... command) {
-        this.command = Arrays.asList(command);
+    	this(Arrays.asList(command));
     }
 
     public List<String> command() {
@@ -40,6 +41,20 @@ public class ProcessBuilder {
         this.command = Arrays.asList(command);
         return this;
     }
+    
+    /**
+     * Returns a string map view of this process builder's environment.  Whenever a process builder is created, the environment
+     * is initialized to a copy of the current process environment (See {@link System#getenv()}).  Subprocesses subsequently
+     * started by this object's {@link #start()} method will use this map as their environment.
+     * <p>
+     * The returned object may be modified using ordinary {@link Map} operators.
+     * 
+     * @return
+     * 		The process builder's environment.
+     */
+    public Map<String, String> environment() {
+    	return this.env;
+    }
 
     public Process start() {
         int[] stdin = new int[2];
@@ -53,7 +68,7 @@ public class ProcessBuilder {
 
         // build env list
         ArrayList<String> envp = new ArrayList<String>();
-        for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+        for (Map.Entry<String, String> entry : env.entrySet()) {
             envp.add(entry.getKey() + "=" + entry.getValue());
         }
 

--- a/src/test/java/jnr/process/TestProcessBuilder.java
+++ b/src/test/java/jnr/process/TestProcessBuilder.java
@@ -20,4 +20,20 @@ public class TestProcessBuilder {
         
         assertArrayEquals("hello".getBytes(), hello);
     }
+    
+    @Test
+    public void testEnvironmentVariables() throws Exception {
+    	String value = "environment variable";
+    	
+    	ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", "echo \"$envVar\"");
+    	pb.environment().put("envVar", value);
+    	
+    	Process p = pb.start();
+    	
+    	byte[] message = new byte[value.getBytes().length];
+    	p.getInputStream().read(message);
+    	
+    	assertEquals(0, p.waitFor());
+    	assertArrayEquals(value.getBytes(), message);
+    }
 }


### PR DESCRIPTION
- Fixed a type error in Process.java which was calling `Posix.kill(...)`, which was expecting an `int` pid, with a `long` pid.  Fixed this by casing the pid to an `int` to the `kill` calls.
- Added the `ProcessBuilder.environment()` method, which is based on the same method found in `java.lang.ProcessBuilder`.
